### PR TITLE
Rename getOrders() to summaries()

### DIFF
--- a/scripts/waffles.coffee
+++ b/scripts/waffles.coffee
@@ -13,7 +13,7 @@ module.exports = (robot) ->
   timeoutId = null
 
   # produces a summary of current orders
-  getOrders = () ->
+  summaries = () ->
     output = 'Orders so far:\n'
     for waffleType in waffleTypes
       nameList = robot.brain.get(waffleType)
@@ -73,12 +73,12 @@ module.exports = (robot) ->
         timeoutId = null
 
       timeoutId = setTimeout () ->
-          msg.reply getOrders()
+          msg.reply summaries()
         , 5 * 1000
 
-  robot.hear /(consolidate|orders)/i, (msg) ->
+  robot.hear /(summaries|consolidate|orders)/i, (msg) ->
     if isOrderActive()
-      msg.reply getOrders()
+      msg.reply summaries()
       # cancel the scheduled summary display if there's one
       if timeoutId?
         clearTimeout(timeoutId)

--- a/scripts/waffles.coffee
+++ b/scripts/waffles.coffee
@@ -10,8 +10,6 @@
 waffleTypes = ['chocolate', 'cheese', 'kaya', 'peanut', 'blueberry', 'plain']
 
 module.exports = (robot) ->
-  timeoutId = null
-
   # produces a summary of current orders
   summaries = () ->
     output = 'Orders so far:\n'
@@ -20,7 +18,6 @@ module.exports = (robot) ->
       numType = nameList.length
       names = getNames nameList
       output += "#{waffleType}: #{numType} #{names}\n" if numType != 0
-    timeoutId = null
     output
 
   # produces a nice comma separated string of names surrounded by parantheses
@@ -65,21 +62,8 @@ module.exports = (robot) ->
       nameList = robot.brain.get(waffleType)
       nameList.push(msg.message.user.name)
       robot.brain.set waffleType, nameList
-      msg.reply "#{waffleType} order received!"
-
-      # if timeoutId is not null (existing timeout), clear it
-      if timeoutId?
-        clearTimeout(timeoutId)
-        timeoutId = null
-
-      timeoutId = setTimeout () ->
-          msg.reply summaries()
-        , 5 * 1000
+      msg.reply "#{summaries()}"
 
   robot.hear /(summaries|consolidate|orders)/i, (msg) ->
     if isOrderActive()
       msg.reply summaries()
-      # cancel the scheduled summary display if there's one
-      if timeoutId?
-        clearTimeout(timeoutId)
-        timeoutId = null


### PR DESCRIPTION
Remove timeouts and display summaries immediately instead.
