### PR TITLE
Upgrade hubot-slack to v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "hubot-rules": "^0.1.0",
     "hubot-scripts": "^2.0.0",
     "hubot-shipit": "^0.2.0",
-    "hubot-slack": "^3.0.0",
+    "hubot-slack": "^4.0.0",
     "hubot-standup-alarm": "0.0.7",
     "hubot-xkcd": "0.0.3"
   },


### PR DESCRIPTION
slackhq/hubot-slack v4.0.0 was [released 2 days ago](https://github.com/slackhq/hubot-slack/releases/tag/4.0.0), with the release notes mentioning:

> - Better (and automatically enabled) reconnect logic. As in, it actually reconnects automatically at all.
- Resolves some connection issues, see: slackhq/hubot-slack#309
- Fixes #32 
