### PR TITLE
Replace Math.floor with Math.round for consistent roundings

### DIFF
--- a/scripts/bozzcoin.coffee
+++ b/scripts/bozzcoin.coffee
@@ -26,7 +26,7 @@ module.exports = (robot) ->
       else return 0
 
   convertToBozzcoin = (reps, exerciseType) ->
-    return Math.floor(reps * earnRate(exerciseType))
+    return Math.round(reps * earnRate(exerciseType))
 
   convertToReps = (bozzcoin, exerciseType) ->
     return bozzcoin / earnRate(exerciseType)


### PR DESCRIPTION
When subtracting reps, the results of `Math.floor` is the opposite of that when adding reps.

E.g.
```
Math.floor(0.1)  // gives 0
Math.floor(-0.1) // gives -1
```

Replacing it with `Math.round` gives a consistent calculation for bozzcoins.
  