### PR TITLE
Implement bozziplier

### DIFF
--- a/scripts/bozzcoin.coffee
+++ b/scripts/bozzcoin.coffee
@@ -98,9 +98,10 @@ module.exports = (robot) ->
     if repsDone > 0 && updateBozziplier(username)
       res.send ":bozz: Bozziplier reset like a bozz"
     bozziplier = robot.brain.get("bozziplier")
-    newBozzcoinBalance = robot.brain.get("bozzcoinBalance") + convertToBozzcoin(repsDone, exerciseType)
+    bozzcoinEarned = convertToBozzcoin(repsDone, exerciseType)
+    newBozzcoinBalance = robot.brain.get("bozzcoinBalance") + bozzcoinEarned
     robot.brain.set("bozzcoinBalance", newBozzcoinBalance)
-    res.send "#{res.match[1]} #{exerciseType} done with bozzplier of #{bozziplier}, *#{newBozzcoinBalance}* :bozzcoin: available!"
+    res.send "#{res.match[1]} #{exerciseType} done, earned *#{bozzcoinEarned}* :bozzcoin: with bozziplier of #{bozziplier}.\n*#{newBozzcoinBalance}* :bozzcoin: available!"
     if (username of bozzcoinTracker)
       bozzcoinTracker[username] += convertToBozzcoin(repsDone, exerciseType)
     else

--- a/scripts/bozzcoin.coffee
+++ b/scripts/bozzcoin.coffee
@@ -9,7 +9,9 @@
 
 module.exports = (robot) ->
   # number of days bozz can go without exercising
-  bozziplierThreshold = 1
+  bozziplierThreshold = 2
+  # multiplier decay for bozziplier
+  bozziplierDecay = 0.8
 
   # produces a summary of who has contributed bozzcoins
   bozzcoinSummaries = () ->
@@ -39,8 +41,10 @@ module.exports = (robot) ->
       bozzLastExercised = robot.brain.get("bozzLastExercised")
       if !bozzLastExercised || new Date().getTime() - new Date(bozzLastExercised).getTime() > bozziplierThreshold * 86400000 # threshold times milliseconds in a day
         bozziplier = robot.brain.get("bozziplier")
-        if !bozziplier then bozziplier = 1
-        newBozziplier = bozziplier * 0.5
+        if !bozziplier
+          bozziplier = 1
+          robot.brain.set("bozzLastExercised", new Date())
+        newBozziplier = bozziplier * bozziplierDecay
         robot.brain.set("bozziplier", newBozziplier)
     return false
 

--- a/scripts/bozzcoin.coffee
+++ b/scripts/bozzcoin.coffee
@@ -8,6 +8,9 @@
 #   (prata|starbucks|macs) day - subtracts bozzcoins depending on the cheat type.
 
 module.exports = (robot) ->
+  # number of days bozz can go without exercising
+  bozziplierThreshold = 1
+
   # produces a summary of who has contributed bozzcoins
   bozzcoinSummaries = () ->
     output = "\n"
@@ -25,9 +28,22 @@ module.exports = (robot) ->
       when "run" then return 50
       when "racket steps" then return 1 / 18
       else return 0
+  
+  # returns true if bozziplier is reset
+  updateBozziplier = (username) ->
+    if username is "rurouni"
+      robot.brain.set("bozzLastExercised", new Date())
+      return true
+    else
+      bozzLastExercised = robot.brain.get("bozzLastExercised")
+      if !bozzLastExercised || new Date().getTime() - new Date(bozzLastExercised).getTime() > bozziplierThreshold * 86400000 # threshold times milliseconds in a day
+        bozziplier = robot.brain.get("bozziplier")
+        newBozziplier = bozziplier * 0.5
+        robot.brain.set("bozziplier", newBozziplier)
+    return false
 
   convertToBozzcoin = (reps, exerciseType) ->
-    return Math.round(reps * earnRate(exerciseType))
+    return Math.round(reps * earnRate(exerciseType) * robot.brain.get("bozziplier"))
 
   convertToReps = (bozzcoin, exerciseType) ->
     return bozzcoin / earnRate(exerciseType)
@@ -79,9 +95,12 @@ module.exports = (robot) ->
         if repsDone > 13000
           res.send "Are you sure you can play longer than :pohneo:?"
           return
+    if repsDone > 0 && updateBozziplier(username)
+      res.send ":bozz: Bozziplier reset like a bozz"
+    bozziplier = robot.brain.get("bozziplier")
     newBozzcoinBalance = robot.brain.get("bozzcoinBalance") + convertToBozzcoin(repsDone, exerciseType)
     robot.brain.set("bozzcoinBalance", newBozzcoinBalance)
-    res.send "#{res.match[1]} #{exerciseType} done, *#{newBozzcoinBalance}* :bozzcoin: available!"
+    res.send "#{res.match[1]} #{exerciseType} done with bozzplier of #{bozziplier}, *#{newBozzcoinBalance}* :bozzcoin: available!"
     if (username of bozzcoinTracker)
       bozzcoinTracker[username] += convertToBozzcoin(repsDone, exerciseType)
     else
@@ -99,6 +118,8 @@ module.exports = (robot) ->
     if distanceInKm < (-1 * distanceByUser)
       res.send "You can't undo more than you have done"
       return
+    if distanceInKm > 0 && updateBozziplier(username)
+      res.send ":bozz: Bozziplier reset like a bozz"
     newBozzcoinBalance = robot.brain.get("bozzcoinBalance") + convertToBozzcoin(distanceInKm, "run")
     robot.brain.set("bozzcoinBalance", newBozzcoinBalance)
     res.send "#{distanceInKm.toFixed(3)} km ran, *#{newBozzcoinBalance}* :bozzcoin: available!"

--- a/scripts/bozzcoin.coffee
+++ b/scripts/bozzcoin.coffee
@@ -33,11 +33,13 @@ module.exports = (robot) ->
   updateBozziplier = (username) ->
     if username is "rurouni"
       robot.brain.set("bozzLastExercised", new Date())
+      robot.brain.set("bozziplier", 1)
       return true
     else
       bozzLastExercised = robot.brain.get("bozzLastExercised")
       if !bozzLastExercised || new Date().getTime() - new Date(bozzLastExercised).getTime() > bozziplierThreshold * 86400000 # threshold times milliseconds in a day
         bozziplier = robot.brain.get("bozziplier")
+        if !bozziplier then bozziplier = 1
         newBozziplier = bozziplier * 0.5
         robot.brain.set("bozziplier", newBozziplier)
     return false


### PR DESCRIPTION
Implemented a bozz multiplier (bozziplier) where a sub-1 multiplier will be applied to all bozzcoin contributions should bozz not exercise for a certain number of days, determined by `bozziplierThreshold`.

Bozziplier is updated before every exercise entry if they're positive contributions. 

Bozziplier is reset to 1 every time bozz contributes.

Future: might want to set a minimum number of bozzcoins contributed by bozz within the threshold before the multiplier resets